### PR TITLE
Fix acronym and update capitalizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Xpring SDK is a set of libraries and services designed to make interaction with 
 
 ### Libraries
 
-Xpring SDK provides commonly used functionality for the XRP Ledger and InterLedger Protocol (ILP). Functionality and programming paradigms are common across all libraries in Xpring SDK.
+Xpring SDK provides commonly used functionality for the XRP Ledger and Interledger Protocol (ILP). Functionality and programming paradigms are common across all libraries in Xpring SDK.
 
-Xpring SDK provides the following features when used with the XRPL Ledger protocol:
+Xpring SDK provides the following features when used with the XRP Ledger protocol:
 - Wallet generation and derivation (Seed-based or HD Wallet-based)
 - Address validation
 - Account balance retrieval
@@ -17,7 +17,7 @@ Xpring SDK provides the following features when used with the XRPL Ledger protoc
 - Transaction Status
 - Payment History
 
-Xpring SDK provides the following features when used with InterLedger protocols:
+Xpring SDK provides the following features when used with Interledger protocols:
 - Sending payments
 - Checking account balance
 
@@ -28,13 +28,13 @@ Xpring SDK is available in the following languages:
 
 ### Remote Node
 
-Xpring SDK connects to a remote [rippled node](https://github.com/ripple/rippled) or [interledger node](https://github.com/xpring-eng/hermes-ilp).
+Xpring SDK connects to a remote [rippled node](https://github.com/ripple/rippled) or [Interledger node](https://github.com/xpring-eng/hermes-ilp).
 
 Xpring recommends users of the SDK run their own nodes. However, Xpring recognizes that users may want to rapidly prototype without running their own infrastructure. As a result, we run the following public nodes which users can connect to:
 
 
 ```
-# Rippled
+# rippled
 ## Mainnet
 main.xrp.xpring.io:50051         # Outside of a browser
 https://envoy.main.xrp.xpring.io # Inside of a browser


### PR DESCRIPTION
- Interledger is written with a lowercase `l`
- The `L` in `XRPL` stands for `Ledger` already - `XRP Ledger protocol` is correct
- rippled is written with a lowercase `r`